### PR TITLE
[RoPE] Add rotary positional encoding in attention head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ ipython_config.py
 .pdm-python
 .pdm-build/
 
+# uv
+uv.lock
+
 # pixi
 #   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
 # pixi.lock

--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ tensorboard --logdir outputs/
   year={2020}
 }
 ```
+
+```bibtex
+@article{su2024roformer,
+  title={Roformer: Enhanced transformer with rotary position embedding},
+  author={Su, Jianlin and Ahmed, Murtadha and Lu, Yu and Pan, Shengfeng and Bo, Wen and Liu, Yunfeng},
+  journal={Neurocomputing},
+  volume={568},
+  pages={127063},
+  year={2024},
+  publisher={Elsevier}
+}
+```

--- a/config/model/pos_encoding/freq_1d.yaml
+++ b/config/model/pos_encoding/freq_1d.yaml
@@ -1,0 +1,2 @@
+_target_: src.encodings.freq_1d.Frequency1DEncoding
+dim: ${model.dim}

--- a/config/model/pos_encoding/identity.yaml
+++ b/config/model/pos_encoding/identity.yaml
@@ -1,0 +1,1 @@
+_target_: src.encodings.identity.IdentityEncoding

--- a/config/model/rope_encoding.yaml
+++ b/config/model/rope_encoding.yaml
@@ -1,0 +1,3 @@
+defaults:
+  - encoder_only_small
+  - override pos_encoding: identity

--- a/config/model/rope_encoding.yaml
+++ b/config/model/rope_encoding.yaml
@@ -5,5 +5,4 @@ defaults:
 $mha:
   relative_pos_encoding:
     _target_: src.encodings.rope.RotaryPositionalEncoding
-    dim: ${model.dim}
-    n_heads: ${model.$mha.n_heads}
+    dim: 12

--- a/config/model/rope_encoding.yaml
+++ b/config/model/rope_encoding.yaml
@@ -5,5 +5,5 @@ defaults:
 $mha:
   relative_pos_encoding:
     _target_: src.encodings.rope.RotaryPositionalEncoding
-    dim: 384
-    n_heads: 8
+    dim: ${model.dim}
+    n_heads: ${model.$mha.n_heads}

--- a/config/model/rope_encoding.yaml
+++ b/config/model/rope_encoding.yaml
@@ -1,3 +1,9 @@
 defaults:
   - encoder_only_small
   - override pos_encoding: identity
+
+$mha:
+  relative_pos_encoding:
+    _target_: src.encodings.rope.RotaryPositionalEncoding
+    dim: 384
+    n_heads: 8

--- a/config/model/vanilla_base.yaml
+++ b/config/model/vanilla_base.yaml
@@ -1,3 +1,7 @@
+defaults:
+  - _self_
+  - pos_encoding: freq_1d
+
 _target_: src.models.transformer.Transformer
 
 # Transformer Args
@@ -21,11 +25,6 @@ $ff:
     _target_: torch.nn.GELU
   gated: true
   dropout: ${model.$dropout}
-
-# Submodules
-pos_encoding:
-  _target_: src.encodings.freq_1d.Frequency1DEncoding
-  dim: ${model.dim}
 
 encoder:
   _target_: src.blocks.encoder.TransformerEncoder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,11 @@ dependencies = [
     "matplotlib==3.10.7",
     "tqdm==4.67.1",
     # Core
-  # "torch",        # Manually install to match Accelerator version
-  # "torchvision",  # Manually install to match Accelerator version
-  # "lightning",  # Manually install to match Accelerator version
+    # "torch",        # Manually install to match Accelerator version
+    # "torchvision",  # Manually install to match Accelerator version
+    # "lightning",  # Manually install to match Accelerator version
     "einops==0.8.1",
+    "rotary-embedding-torch>=0.8.9",
 ]
 authors = [
   {name = "Cyril Moser"},

--- a/src/blocks/mha.py
+++ b/src/blocks/mha.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -6,7 +7,7 @@ from einops import rearrange
 from rotary_embedding_torch import RotaryEmbedding
 from torch import Tensor
 
-from src.interfaces import AttentionBase
+from src.interfaces import AttentionBase, BaseRelativePositionalEncoding
 from src.utils import get_forward_metadata
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class MultiHeadAttention(AttentionBase):
         q_dim: int = None,
         ctx_dim: int = None,
         dropout: float = 0.0,
+        relative_pos_encoding: Optional[BaseRelativePositionalEncoding] = None,
     ):
         """Initialize multi-head attention.
 
@@ -33,6 +35,7 @@ class MultiHeadAttention(AttentionBase):
             q_dim: Query dimensionality (defaults to dim).
             ctx_dim: Context dimensionality (defaults to dim).
             dropout: Dropout rate.
+            relative_pos_encoding: Relative positional encoding (defaults to None)
         """
         super().__init__()
 
@@ -50,8 +53,7 @@ class MultiHeadAttention(AttentionBase):
         self.output = torch.nn.Linear(dim, q_dim, bias=embed_bias)
 
         self.dropout = nn.Dropout(dropout)
-        self.rope_h = RotaryEmbedding(dim=dim_head // 2)
-        self.rope_w = RotaryEmbedding(dim=dim_head // 2)
+        self.relative_pos_encoding = relative_pos_encoding
 
     def forward(
         self,
@@ -59,18 +61,16 @@ class MultiHeadAttention(AttentionBase):
         ctx: Tensor,
         mask: torch.Tensor = None,
     ) -> tuple[Tensor, Tensor]:
-        orig_shape = get_forward_metadata("orig_shape")
-        _, h, w = orig_shape
-
         # Apply projection
         q, k, v = map(lambda f, x: f(x), (self.query, self.key, self.value), (q, ctx, ctx))
 
         # Split into 'n_heads' heads
         q, k, v = map(lambda x: rearrange(x, "b s (h d) -> b h s d", h=self.n_heads), (q, k, v))
 
-        # Apply 2D rotational encoding
-        q = self._apply_2d_rope(q, h, w)
-        k = self._apply_2d_rope(k, h, w)
+        # Apply relative positional encoding if possible
+        if self.relative_pos_encoding is not None:
+            print(f"rel pos enc type: {type(self.relative_pos_encoding)}")
+            q, k = self.relative_pos_encoding(q, k)
 
         # Compute q @ k^T / sqrt(d)
         scores = torch.einsum("b h s d, b h t d -> b h s t", q, k) * self.scale
@@ -93,44 +93,3 @@ class MultiHeadAttention(AttentionBase):
         out = self.dropout(out)
 
         return out, attn
-
-    def _apply_2d_rope(self, x: torch.Tensor, h: int, w: int) -> torch.Tensor:
-        """Apply 2D RoPE encoding to x. The features of x are being splitted into
-        x_h and x_w, and on those two different rotational encoding are being applied.
-        After the encoding, x_h and x_w are again merged into the correct shape.
-
-        Args:
-            x: (b h s d) input tokens (without registers)
-            h: height of the grid
-            w: width of the grid
-        """
-        b, n_heads, s, d_full = x.shape
-        d_half = d_full // 2
-
-        # Remove the head specific registers
-        n_registers = s - (h * w)
-        registers = x[..., :n_registers, :]
-        x = x[..., n_registers:, :]
-
-        x = rearrange(x, "b h (gh gw) d -> b h gh gw d", gh=h, gw=w)
-
-        # Split x in both dimensions
-        x_h = x[..., :d_half]
-        x_w = x[..., d_half:]
-
-        # Apply rope to height
-        x_h = rearrange(x_h, "b h gh gw d -> b (h gw) gh d")
-        x_h = self.rope_h.rotate_queries_or_keys(x_h)
-        x_h = rearrange(x_h, "b (h gw) gh d -> b h (gh gw) d", h=n_heads, gw=w)
-
-        # Apply rope to width
-        x_w = rearrange(x_w, "b h gh gw d -> b (h gh) gw d")
-        x_w = self.rope_h.rotate_queries_or_keys(x_w)
-        x_w = rearrange(x_w, "b (h gh) gw d -> b h (gh gw) d", h=n_heads, gh=h)
-
-        # Concatenate back together
-        x = torch.cat([x_h, x_w], dim=-1)
-
-        # Add registers back
-        x = torch.cat([registers, x], dim=2)
-        return x

--- a/src/blocks/mha.py
+++ b/src/blocks/mha.py
@@ -3,6 +3,7 @@ import logging
 import torch
 import torch.nn as nn
 from einops import rearrange
+from rotary_embedding_torch import RotaryEmbedding
 from torch import Tensor
 
 from src.interfaces import AttentionBase
@@ -49,6 +50,8 @@ class MultiHeadAttention(AttentionBase):
         self.output = torch.nn.Linear(dim, q_dim, bias=embed_bias)
 
         self.dropout = nn.Dropout(dropout)
+        self.rope_h = RotaryEmbedding(dim=dim_head // 2)
+        self.rope_w = RotaryEmbedding(dim=dim_head // 2)
 
     def forward(
         self,
@@ -57,12 +60,17 @@ class MultiHeadAttention(AttentionBase):
         mask: torch.Tensor = None,
     ) -> tuple[Tensor, Tensor]:
         orig_shape = get_forward_metadata("orig_shape")
-        logger.info(f"MultiHeadAttention called with orig_shape={orig_shape}")
+        _, h, w = orig_shape
+
         # Apply projection
         q, k, v = map(lambda f, x: f(x), (self.query, self.key, self.value), (q, ctx, ctx))
 
         # Split into 'n_heads' heads
         q, k, v = map(lambda x: rearrange(x, "b s (h d) -> b h s d", h=self.n_heads), (q, k, v))
+
+        # Apply 2D rotational encoding
+        q = self._apply_2d_rope(q, h, w)
+        k = self._apply_2d_rope(k, h, w)
 
         # Compute q @ k^T / sqrt(d)
         scores = torch.einsum("b h s d, b h t d -> b h s t", q, k) * self.scale
@@ -85,3 +93,44 @@ class MultiHeadAttention(AttentionBase):
         out = self.dropout(out)
 
         return out, attn
+
+    def _apply_2d_rope(self, x: torch.Tensor, h: int, w: int) -> torch.Tensor:
+        """Apply 2D RoPE encoding to x. The features of x are being splitted into
+        x_h and x_w, and on those two different rotational encoding are being applied.
+        After the encoding, x_h and x_w are again merged into the correct shape.
+
+        Args:
+            x: (b h s d) input tokens (without registers)
+            h: height of the grid
+            w: width of the grid
+        """
+        b, n_heads, s, d_full = x.shape
+        d_half = d_full // 2
+
+        # Remove the head specific registers
+        n_registers = s - (h * w)
+        registers = x[..., :n_registers, :]
+        x = x[..., n_registers:, :]
+
+        x = rearrange(x, "b h (gh gw) d -> b h gh gw d", gh=h, gw=w)
+
+        # Split x in both dimensions
+        x_h = x[..., :d_half]
+        x_w = x[..., d_half:]
+
+        # Apply rope to height
+        x_h = rearrange(x_h, "b h gh gw d -> b (h gw) gh d")
+        x_h = self.rope_h.rotate_queries_or_keys(x_h)
+        x_h = rearrange(x_h, "b (h gw) gh d -> b h (gh gw) d", h=n_heads, gw=w)
+
+        # Apply rope to width
+        x_w = rearrange(x_w, "b h gh gw d -> b (h gh) gw d")
+        x_w = self.rope_h.rotate_queries_or_keys(x_w)
+        x_w = rearrange(x_w, "b (h gh) gw d -> b h (gh gw) d", h=n_heads, gh=h)
+
+        # Concatenate back together
+        x = torch.cat([x_h, x_w], dim=-1)
+
+        # Add registers back
+        x = torch.cat([registers, x], dim=2)
+        return x

--- a/src/blocks/mha.py
+++ b/src/blocks/mha.py
@@ -1,9 +1,14 @@
+import logging
+
 import torch
 import torch.nn as nn
 from einops import rearrange
 from torch import Tensor
 
 from src.interfaces import AttentionBase
+from src.utils import get_forward_metadata
+
+logger = logging.getLogger(__name__)
 
 
 class MultiHeadAttention(AttentionBase):
@@ -51,6 +56,8 @@ class MultiHeadAttention(AttentionBase):
         ctx: Tensor,
         mask: torch.Tensor = None,
     ) -> tuple[Tensor, Tensor]:
+        orig_shape = get_forward_metadata("orig_shape")
+        logger.info(f"MultiHeadAttention called with orig_shape={orig_shape}")
         # Apply projection
         q, k, v = map(lambda f, x: f(x), (self.query, self.key, self.value), (q, ctx, ctx))
 

--- a/src/blocks/mha.py
+++ b/src/blocks/mha.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from einops import rearrange
 from torch import Tensor
 
-from src.interfaces import AttentionBase, BaseRelativePositionalEncoding
+from src.interfaces import AttentionBase, RelativePositionalEncodingBase
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class MultiHeadAttention(AttentionBase):
         q_dim: int = None,
         ctx_dim: int = None,
         dropout: float = 0.0,
-        relative_pos_encoding: Optional[BaseRelativePositionalEncoding] = None,
+        relative_pos_encoding: Optional[RelativePositionalEncodingBase] = None,
     ):
         """Initialize multi-head attention.
 

--- a/src/blocks/mha.py
+++ b/src/blocks/mha.py
@@ -4,11 +4,9 @@ from typing import Optional
 import torch
 import torch.nn as nn
 from einops import rearrange
-from rotary_embedding_torch import RotaryEmbedding
 from torch import Tensor
 
 from src.interfaces import AttentionBase, BaseRelativePositionalEncoding
-from src.utils import get_forward_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +67,6 @@ class MultiHeadAttention(AttentionBase):
 
         # Apply relative positional encoding if possible
         if self.relative_pos_encoding is not None:
-            print(f"rel pos enc type: {type(self.relative_pos_encoding)}")
             q, k = self.relative_pos_encoding(q, k)
 
         # Compute q @ k^T / sqrt(d)

--- a/src/encodings/identity.py
+++ b/src/encodings/identity.py
@@ -1,0 +1,10 @@
+from torch import Size, Tensor
+
+from src.interfaces import PositionalEncodingBase
+
+
+class IdentityEncoding(PositionalEncodingBase):
+    """Identity encoding"""
+
+    def forward(self, x: Tensor, orig_size: Size) -> Tensor:
+        return x

--- a/src/encodings/rope.py
+++ b/src/encodings/rope.py
@@ -3,28 +3,26 @@ from einops import rearrange
 from rotary_embedding_torch import RotaryEmbedding
 from torch import Size, Tensor
 
-from src.interfaces import BaseRelativePositionalEncoding
+from src.interfaces import RelativePositionalEncodingBase
 from src.utils import get_forward_metadata
 
 
-class RotaryPositionalEncoding(BaseRelativePositionalEncoding):
+class RotaryPositionalEncoding(RelativePositionalEncodingBase):
     """Rotary positional encoding (Su et al., 2021)"""
 
-    def __init__(self, dim: int, n_heads: int):
+    def __init__(self, dim: int, n_heads: int, theta: float = 10_000):
         """Initialize rotary positional encoding.
 
         Args:
             dim: Token dimensionality.
             n_heads: Number of attention heads.
+            theta: Base frequency for rotary embeddings.
         """
         super().__init__()
 
-        print(f"initialize with dim: {dim} and n_heads: {n_heads}")
-
         # We apply the rotary embedding to each token in every head separately.
         dim_head = dim // n_heads  # this better be even
-        self.rope_h = RotaryEmbedding(dim=dim_head // 2)
-        self.rope_w = RotaryEmbedding(dim=dim_head // 2)
+        self.rope = RotaryEmbedding(dim=dim_head // 2, theta=theta)
 
     def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:
         # Fetch the grid size
@@ -34,7 +32,7 @@ class RotaryPositionalEncoding(BaseRelativePositionalEncoding):
         q = self._apply_2d_rope(q, h, w)
         k = self._apply_2d_rope(k, h, w)
 
-        return (q, k)
+        return q, k
 
     def _apply_2d_rope(self, x: Tensor, h: int, w: int) -> Tensor:
         """Apply 2D RoPE encoding to x. The features of x are being splitted into
@@ -62,12 +60,12 @@ class RotaryPositionalEncoding(BaseRelativePositionalEncoding):
 
         # Apply rope to height
         x_h = rearrange(x_h, "b h gh gw d -> b (h gw) gh d")
-        x_h = self.rope_h.rotate_queries_or_keys(x_h)
+        x_h = self.rope.rotate_queries_or_keys(x_h)
         x_h = rearrange(x_h, "b (h gw) gh d -> b h (gh gw) d", h=n_heads, gw=w)
 
         # Apply rope to width
         x_w = rearrange(x_w, "b h gh gw d -> b (h gh) gw d")
-        x_w = self.rope_h.rotate_queries_or_keys(x_w)
+        x_w = self.rope.rotate_queries_or_keys(x_w)
         x_w = rearrange(x_w, "b (h gh) gw d -> b h (gh gw) d", h=n_heads, gh=h)
 
         # Concatenate back together

--- a/src/encodings/rope.py
+++ b/src/encodings/rope.py
@@ -1,0 +1,74 @@
+import torch
+from einops import rearrange
+from rotary_embedding_torch import RotaryEmbedding
+from torch import Size, Tensor
+
+from src.interfaces import BaseRelativePositionalEncoding
+from src.utils import get_forward_metadata
+
+
+class RotaryPositionalEncoding(BaseRelativePositionalEncoding):
+    """Rotary positional encoding (Su et al., 2021)"""
+
+    def __init__(self, dim: int, n_heads: int):
+        """Initialize rotary positional encoding.
+
+        Args:
+            dim: Token dimensionality.
+            n_heads: Number of attention heads.
+        """
+
+        # We apply the rotary embedding to each token in every head separately.
+        self.rope_h = RotaryEmbedding(dim=dim // n_heads)
+        self.rope_w = RotaryEmbedding(dim=dim // n_heads)
+
+    def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:
+        # Fetch the grid size
+        orig_shape = get_forward_metadata("orig_shape")
+        _, h, w = orig_shape
+
+        q = self._apply_2d_rope(q, h, w)
+        k = self._apply_2d_rope(k, h, w)
+
+        return (q, k)
+
+    def _apply_2d_rope(self, x: Tensor, h: int, w: int) -> Tensor:
+        """Apply 2D RoPE encoding to x. The features of x are being splitted into
+        x_h and x_w, and on those two different rotational encoding are being applied.
+        After the encoding, x_h and x_w are again merged into the correct shape.
+
+        Args:
+            x: (b h s d) input tokens (with potential registers)
+            h: height of the grid
+            w: width of the grid
+        """
+        b, n_heads, s, d_full = x.shape
+        d_half = d_full // 2
+
+        # Remove the head specific registers
+        n_registers = s - (h * w)
+        registers = x[..., :n_registers, :]
+        x = x[..., n_registers:, :]
+
+        x = rearrange(x, "b h (gh gw) d -> b h gh gw d", gh=h, gw=w)
+
+        # Split x in both dimensions
+        x_h = x[..., :d_half]
+        x_w = x[..., d_half:]
+
+        # Apply rope to height
+        x_h = rearrange(x_h, "b h gh gw d -> b (h gw) gh d")
+        x_h = self.rope_h.rotate_queries_or_keys(x_h)
+        x_h = rearrange(x_h, "b (h gw) gh d -> b h (gh gw) d", h=n_heads, gw=w)
+
+        # Apply rope to width
+        x_w = rearrange(x_w, "b h gh gw d -> b (h gh) gw d")
+        x_w = self.rope_h.rotate_queries_or_keys(x_w)
+        x_w = rearrange(x_w, "b (h gh) gw d -> b h (gh gw) d", h=n_heads, gh=h)
+
+        # Concatenate back together
+        x = torch.cat([x_h, x_w], dim=-1)
+
+        # Add registers back
+        x = torch.cat([registers, x], dim=2)
+        return x

--- a/src/encodings/rope.py
+++ b/src/encodings/rope.py
@@ -17,10 +17,14 @@ class RotaryPositionalEncoding(BaseRelativePositionalEncoding):
             dim: Token dimensionality.
             n_heads: Number of attention heads.
         """
+        super().__init__()
+
+        print(f"initialize with dim: {dim} and n_heads: {n_heads}")
 
         # We apply the rotary embedding to each token in every head separately.
-        self.rope_h = RotaryEmbedding(dim=dim // n_heads)
-        self.rope_w = RotaryEmbedding(dim=dim // n_heads)
+        dim_head = dim // n_heads  # this better be even
+        self.rope_h = RotaryEmbedding(dim=dim_head // 2)
+        self.rope_w = RotaryEmbedding(dim=dim_head // 2)
 
     def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:
         # Fetch the grid size

--- a/src/encodings/rope.py
+++ b/src/encodings/rope.py
@@ -10,7 +10,7 @@ from src.utils import get_forward_metadata
 class RotaryPositionalEncoding(RelativePositionalEncodingBase):
     """Rotary positional encoding (Su et al., 2021)"""
 
-    def __init__(self, dim: int, n_heads: int, theta: float = 10_000):
+    def __init__(self, dim: int, theta: float = 10_000):
         """Initialize rotary positional encoding.
 
         Args:
@@ -20,9 +20,9 @@ class RotaryPositionalEncoding(RelativePositionalEncodingBase):
         """
         super().__init__()
 
-        # We apply the rotary embedding to each token in every head separately.
-        dim_head = dim // n_heads  # this better be even
-        self.rope = RotaryEmbedding(dim=dim_head // 2, theta=theta)
+        # The user is responsible for ensuring that dim is correctly set
+        self.dim = dim
+        self.rope = RotaryEmbedding(dim=dim, theta=theta)
 
     def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:
         # Fetch the grid size
@@ -45,18 +45,21 @@ class RotaryPositionalEncoding(RelativePositionalEncodingBase):
             w: width of the grid
         """
         b, n_heads, s, d_full = x.shape
-        d_half = d_full // 2
 
         # Remove the head specific registers
         n_registers = s - (h * w)
         registers = x[..., :n_registers, :]
         x = x[..., n_registers:, :]
 
-        x = rearrange(x, "b h (gh gw) d -> b h gh gw d", gh=h, gw=w)
+        # Not all features are used for rope
+        x_rope = x[..., : 2 * self.dim]
+        x_keep = x[..., 2 * self.dim :]
+
+        x_rope = rearrange(x_rope, "b h (gh gw) d -> b h gh gw d", gh=h, gw=w)
 
         # Split x in both dimensions
-        x_h = x[..., :d_half]
-        x_w = x[..., d_half:]
+        x_h = x_rope[..., : self.dim]
+        x_w = x_rope[..., self.dim : 2 * self.dim]
 
         # Apply rope to height
         x_h = rearrange(x_h, "b h gh gw d -> b (h gw) gh d")
@@ -69,7 +72,7 @@ class RotaryPositionalEncoding(RelativePositionalEncodingBase):
         x_w = rearrange(x_w, "b (h gh) gw d -> b h (gh gw) d", h=n_heads, gh=h)
 
         # Concatenate back together
-        x = torch.cat([x_h, x_w], dim=-1)
+        x = torch.cat([x_h, x_w, x_keep], dim=-1)
 
         # Add registers back
         x = torch.cat([registers, x], dim=2)

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -85,7 +85,7 @@ class PositionalEncodingBase(nn.Module, metaclass=ABCMeta):
         __call__ = forward
 
 
-class BaseRelativePositionalEncoding(nn.Module, metaclass=ABCMeta):
+class RelativePositionalEncodingBase(nn.Module, metaclass=ABCMeta):
     """Abstract class for relative positional encodings."""
 
     def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -85,6 +85,28 @@ class PositionalEncodingBase(nn.Module, metaclass=ABCMeta):
         __call__ = forward
 
 
+class BaseRelativePositionalEncoding(nn.Module, metaclass=ABCMeta):
+    """Abstract class for relative positional encodings."""
+
+    def forward(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:
+        """Apply relative encoding between q and k. Matrices
+
+        Args:
+            q: (b h s d) Query sequence splitted over heads.
+            k: (b h s d) Key sequence splitted over heads.
+
+        Returns:
+            Tuple of (encoded_q, encoded_k)
+
+            - encoded_q: (b h s d) relative encoded queries
+            - encoded_k: (b h s d) relative encoded keys
+        """
+        ...
+
+    if typing.TYPE_CHECKING:
+        __call__ = forward
+
+
 class AttentionBase(nn.Module, metaclass=ABCMeta):
     """Abstract class for attention mechanisms."""
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,7 @@
+from contextvars import ContextVar
+from contextlib import contextmanager
+from typing import Optional, Any
+
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset
 
@@ -23,3 +27,23 @@ def build_data_loader(dataset: Dataset, cfg: DictConfig, train: bool = False) ->
         num_workers=cfg.runtime.n_workers,
         pin_memory=cfg.runtime.pin_memory,
     )
+
+
+# Context variable to pass metadata down to all submodules
+_forward_metadata: ContextVar[Optional[dict]] = ContextVar("forward_metadata", default=None)
+
+
+@contextmanager
+def forward_context(**metadata):
+    """Context manager to set metadata accessible anywhere in the call stack."""
+    token = _forward_metadata.set(metadata)
+    try:
+        yield
+    finally:
+        _forward_metadata.reset(token)
+
+
+def get_forward_metadata(key: str, default: Any = None) -> Any:
+    """Retrieve metadata from the current context."""
+    metadata = _forward_metadata.get()
+    return metadata.get(key, default) if metadata else default

--- a/train.py
+++ b/train.py
@@ -16,7 +16,7 @@ from torchinfo import summary
 from tqdm import tqdm
 
 from src.interfaces import DatasetBase, TransformerBase, TransformerHeadBase
-from src.utils import build_data_loader, drop_helpers
+from src.utils import build_data_loader, drop_helpers, forward_context
 
 logger = logging.getLogger(__name__)
 
@@ -146,19 +146,20 @@ class Trainer:
     ) -> tuple[
         Tensor, Tensor, Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor], Optional[Tensor], Optional[Tensor]
     ]:
-        x_in, x_out = batch
+        with forward_context(orig_shape=batch[0].shape):
+            x_in, x_out = batch
 
-        src, tgt = self.model.prepare_tokens(x_in, x_in, self.head)  # todo: check if this makes sense
-        enc_out, dec_out, enc_attns, dec_self_attns, dec_cross_attns = self.model(src, tgt)
+            src, tgt = self.model.prepare_tokens(x_in, x_in, self.head)  # todo: check if this makes sense
+            enc_out, dec_out, enc_attns, dec_self_attns, dec_cross_attns = self.model(src, tgt)
 
-        y_pred = self.head(dec_out if dec_out is not None else enc_out)
+            y_pred = self.head(dec_out if dec_out is not None else enc_out)
 
-        if x_out is not None:
-            loss, accuracy = self.head.forward_loss(y_pred, x_in, x_out)
-        else:
-            loss = accuracy = self.fabric.to_device(torch.tensor(0.0))
+            if x_out is not None:
+                loss, accuracy = self.head.forward_loss(y_pred, x_in, x_out)
+            else:
+                loss = accuracy = self.fabric.to_device(torch.tensor(0.0))
 
-        return loss, accuracy, y_pred, enc_out, dec_out, enc_attns, dec_self_attns, dec_cross_attns
+            return loss, accuracy, y_pred, enc_out, dec_out, enc_attns, dec_self_attns, dec_cross_attns
 
     def solve(self, epoch: int):
         sample = self.fabric.to_device(self.dataset.get_example())


### PR DESCRIPTION
Because we might want to add more relative positional encodings, which are added to the MAH, I've generalized them into a base class `BaseRelativePositionalEncoding`.

- Added `BaseRelativePositionalEncoding` which take in the **transformed** $q$ and $k$.
- Added the rotary encoding of (Su et al., 2021)[https://arxiv.org/abs/2104.09864]. I've decided to split the token dimension into two parts, and use one of them for the horizontal and the other one for the vertical encoding. Afterwards they get concatenated again.
- Added new config model config `rope_encoding.yaml` which now generalizes to 4 digit addition :tada:

**Disclaimer**: I've seen that some heads add registers. Currently they are added in front of the tokens. The relative positional encoding should ignore them, thus I assumed in my implemenation that these registers are put **in front**.