### PR TITLE
[Plotting] Add plotting utilities + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ python3 train.py model=encoder_only_small dataset.n_samples=1000
 tensorboard --logdir outputs/
 ```
 
+## Plotting
+
+```
+python plotting/plotter.py \
+--model_dir outputs/lens_transformer_3_3_3_3_1_nomask_proj_grad/2025-12-23/18-38-22 \
+  --ckpt ckpt_0120.pth \
+  --activation_layers \
+      _forward_module.lens.0 \
+      _forward_module.lens.3 \
+      _forward_module.lens.5 \
+      _forward_module.lens.7 \
+      _forward_module.lens.8 \
+  --semantic_kernel_layer _forward_module.lens.0
+```
+
 ## References
 
 ```bibtex

--- a/plotting/plotter.py
+++ b/plotting/plotter.py
@@ -1,0 +1,446 @@
+from pathlib import Path
+import torch
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from einops import rearrange, einsum
+from typing import Any
+from train import Trainer
+from omegaconf import OmegaConf
+from itertools import product
+import numpy as np
+import sys
+import argparse
+
+from traces import InferenceTrace
+from utils import pretty_print_sample, overlay_grid_text
+
+COLOR = "plasma"
+
+
+class Plotter:
+    """Plotting class with different visualization methods."""
+
+    def __init__(self, dataset: Any, trainer: Trainer, output_dir: Path):
+        """Initialize plotting manager.
+
+        Args:
+            dataset: Dataset instance.
+            trainer: Trainer with model to use for inference.
+            output_dir: Directory to model log.
+        """
+        self.dataset = dataset
+        self.trainer = trainer
+        self.plot_dir = output_dir / "plots"
+        self.plot_dir.mkdir(parents=True, exist_ok=True)
+
+        # Plotting settings
+        plt.rcParams["figure.dpi"] = 200
+
+    def plot_probabilities(self, trace: InferenceTrace, filename: str = "token_probs_grid.pdf"):
+        """Plot a grid where Y-axis is Time (Steps) and X-axis is Token Class.
+        Normalized over 3D grid (H, W, Vocab) at each step.
+        Create a pdf with one page showing the full grid.
+
+        Args:
+            trace: Inference trace with predictions.
+            filename: Filename for the output PDF. Defaults to "token_probs_grid.pdf".
+        """
+        pdf_path = self.plot_dir / filename
+
+        steps = trace.completion.steps
+        y_preds = trace.completion.y_preds
+
+        tokens_to_plot = [t for t in self.dataset.token_to_idx if t in "0123456789"]
+
+        n_steps = len(y_preds)
+        n_tokens = len(tokens_to_plot)
+        n_vocab = len(self.dataset.token_to_idx)
+        h, w = self.dataset.h, self.dataset.w
+
+        figsize = (n_tokens * 2, n_steps * 2)
+        fig, axes = plt.subplots(n_steps, n_tokens, figsize=figsize, squeeze=False)
+
+        for step_idx, y_pred in enumerate(y_preds):
+            y_pred_reshaped = rearrange(y_pred, "b (h w) v -> b (h w v)", h=h, w=w)
+            probs = torch.softmax(y_pred_reshaped, dim=-1)[0]
+            probs = rearrange(probs, "(h w v) -> h w v", h=h, w=w, v=n_vocab)
+
+            # Prepare Text Overlay
+            current_state = steps[step_idx][0]
+            grid_str = self.dataset.to_string(current_state)
+
+            # Plot each token's probability heatmap
+            for col_idx, token in enumerate(tokens_to_plot):
+                ax = axes[step_idx, col_idx]
+                ti = self.dataset.token_to_idx.index(token)
+                token_prob = probs[:, :, ti].cpu()
+
+                im = ax.imshow(token_prob, cmap=COLOR, vmin=0, vmax=1)
+                overlay_grid_text(ax, token_prob, grid_str, 0, 1)
+
+                # Formatting
+                ax.set_xticks([])
+                ax.set_yticks([])
+
+                # Labels
+                if step_idx == 0:
+                    ax.set_title(f"Token '{token}'", fontsize=14, fontweight="bold")
+                if col_idx == 0:
+                    ax.set_ylabel(f"Step {step_idx}", fontsize=14, fontweight="bold")
+
+        plt.suptitle("Probability Evolution: Rows=Time, Cols=Token Choice", fontsize=16)
+        plt.tight_layout()
+
+        with PdfPages(pdf_path) as pdf:
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        print(f"Saved probability grid to {pdf_path}")
+
+    def plot_attention_analysis(self, trace: InferenceTrace, filename: str = "attention_maps.pdf"):
+        """Plot attention maps for each layer and head at each step for each updated
+        position. Saves all steps into a multi-page PDF.
+
+        @TODO: Might be interesting to plot when there was wrong prediction.
+
+        Args:
+            trace: Inference trace with attention maps.
+            filename: Filename for the output PDF. Defaults to "attention_maps.pdf".
+        """
+        pdf_path = self.plot_dir / filename
+        n_registers = self.trainer.head.n_registers
+        n_layers = trace.completion.attentions[0].shape[0]
+        n_heads = trace.completion.attentions[0].shape[2]
+        n_steps = trace.n_steps
+        h, w = self.dataset.h, self.dataset.w
+
+        with PdfPages(pdf_path) as pdf:
+            for step_idx in range(n_steps - 1):  # last step doesn't have attention
+                current_step = trace.completion.steps[step_idx][0]
+                grid_str = self.dataset.to_string(current_step)
+                attentions = trace.completion.attentions[step_idx]  # (layers, b, heads, seq_len, seq_len)
+                i, j = trace.completion.indices[step_idx]
+
+                fig, axs = plt.subplots(
+                    n_layers,
+                    n_heads,
+                    figsize=(n_heads * 2, n_layers * 2),
+                    squeeze=False,
+                )
+                for lay, head in product(range(n_layers), range(n_heads)):
+                    ax = axs[lay, head]
+                    attn_map = attentions[
+                        lay, 0, head, n_registers:, n_registers:
+                    ]  # (seq_len, seq_len) and drop registers
+                    attn_map = rearrange(attn_map, "(ha wa) (h w) -> ha wa h w", h=h, w=w, ha=h, wa=w)
+                    im = ax.imshow(attn_map[i, j, :, :-1].cpu(), aspect="auto", cmap=COLOR)
+                    overlay_grid_text(ax, attn_map[i, j, :, :-1].cpu(), grid_str, 0, 1, (i, j))
+                    ax.set_title(f"Layer {lay+1} Head {head+1}", fontsize=10)
+                    fig.colorbar(im, ax=ax)
+                plt.suptitle(
+                    f"Attention Maps at Step {step_idx}, Position ({i},{j})",
+                    fontsize=16,
+                )
+                plt.tight_layout()
+                # Save each figure to the PDF
+                pdf.savefig(fig)
+                plt.close(fig)
+
+        print(f"Saved attention maps to {pdf_path}")
+
+    def plot_layer_activations(self, trace: InferenceTrace, filename: str = "activations.pdf"):
+        """
+        Plots the L2 Energy of activations to show where features are active.
+
+        Args:
+            trace: Inference trace with activations.
+            filename: Filename for the output PDF. Defaults to "activations.pdf".
+        """
+        pdf_path = self.plot_dir / filename
+
+        layer_names = list(trace.completion.activations[0].keys())  # assume same
+        n_layers = len(layer_names)
+
+        with PdfPages(pdf_path) as pdf:
+            for step_idx in range(trace.n_steps - 1):
+                activations = trace.completion.activations[step_idx]
+
+                fig, axes = plt.subplots(1, n_layers, figsize=(3 * n_layers, 3))
+                if n_layers == 0:
+                    axes = [axes]
+
+                for i, name in enumerate(layer_names):
+                    ax = axes[i]
+                    act = activations[name]  # (1, C, H, W)
+
+                    energy_map = torch.norm(act, p=2, dim=1).squeeze()  # (H, W)
+
+                    im = ax.imshow(energy_map, cmap=COLOR)
+                    ax.set_title(f"{name}\n(L2 Energy)")
+                    ax.axis("off")
+
+                plt.suptitle(f"Layer Activations at Step {step_idx}", fontsize=16)
+                plt.tight_layout()
+                pdf.savefig(fig)
+                plt.close(fig)
+
+        print(f"Saved activations to {pdf_path}")
+
+    def plot_conv_kernels(self, filename: str = "kernels.pdf"):
+        """Plot all Conv2D kernels from the model into a multi-page PDF. Average over
+        input channels for visualization.
+
+        Args:
+            filename: Filename for the output PDF. Defaults to "kernels.pdf".
+        """
+        pdf_path = self.plot_dir / filename
+
+        # Automatically find all Conv2d layers
+        conv_layers = [
+            (name, module) for name, module in self.trainer.model.named_modules() if isinstance(module, torch.nn.Conv2d)
+        ]
+
+        with PdfPages(pdf_path) as pdf:
+            for name, layer in conv_layers:
+                weights = layer.weight.detach().cpu()  # (C_out, C_in, K, K)
+                C_out = weights.shape[0]
+                C_in = weights.shape[1]
+
+                # Grid setup
+                nrows = int(C_out**0.5)
+                ncols = (C_out // nrows) + (1 if C_out % nrows != 0 else 0)
+                fig, axes = plt.subplots(nrows, ncols, figsize=(ncols, nrows))
+                fig.suptitle(f"Kernels: {name}\nShape: {weights.shape}", fontsize=10)
+
+                # Handle single filter case
+                if C_out == 1:
+                    axes = [axes]
+                axes_flat = axes.flatten() if isinstance(axes, (list, np.ndarray)) else [axes]
+
+                for i in range(C_out):
+                    ax = axes_flat[i]
+                    kernel = weights[i]  # (C_in, K, K)
+
+                    # For visualization, average over input channels
+                    kernel_img = kernel.mean(dim=0)
+
+                    ax.imshow(kernel_img, cmap="gray" if C_in != 3 else None)
+                    ax.axis("off")
+
+                # Hide unused axes
+                for j in range(i + 1, len(axes_flat)):
+                    axes_flat[j].axis("off")
+
+                plt.tight_layout()
+                pdf.savefig(fig)
+                plt.close(fig)
+
+        print(f"Saved kernels to {pdf_path}")
+
+    def plot_semantic_kernels(
+        self,
+        layer_name: str,
+        embedding_layer: torch.nn.Embedding,
+        filename: str = "semantic_kernels.pdf",
+    ):
+        """Plot cosine similarity between Conv2D kernel entries and token embeddings.
+        Assumes the layer is a Conv2D layer with C_in matching embedding dim. Plots
+        the best matching token for each kernel position and the similarity strength.
+
+        Args:
+            layer_name: Name of Conv2D layer to analyze.
+            embedding_layer: Embedding layer containing token embeddings.
+            filename: Filename for the output PDF. Defaults to "semantic_kernels.pdf".
+        """
+        pdf_path = self.plot_dir / filename
+
+        target_layer = dict(self.trainer.model.named_modules())[layer_name]
+        weights = target_layer.weight.detach().cpu()  # (C_out, C_in, K, K)
+
+        n_filters, n_channels, k_h, k_w = weights.shape
+
+        vocab_embeds = embedding_layer.weight.detach().cpu()  # (vocab_size, embedding_dim)
+
+        assert n_channels == vocab_embeds.shape[1], "Channel mismatch"
+
+        flat_weights = rearrange(weights, "co ci kh kw -> co (kh kw) ci")
+
+        # Normalize for cosine similarity
+        w_norm = torch.nn.functional.normalize(flat_weights, p=2, dim=-1)
+        e_norm = torch.nn.functional.normalize(vocab_embeds, p=2, dim=-1)
+
+        similarity = einsum(w_norm, e_norm, "co kw ci, v ci -> co kw v")  # (C_out, kw, vocab_size)
+
+        # Find Best Matches
+        max_vals, max_ids = similarity.max(dim=-1)
+
+        max_vals = rearrange(max_vals, "co (kh kw) -> co kh kw", kh=k_h, kw=k_w)
+        max_ids = rearrange(max_ids, "co (kh kw) -> co kh kw", kh=k_h, kw=k_w)
+
+        # Setup plot grid
+        nrows = int(n_filters**0.5)
+        ncols = (n_filters // nrows) + (1 if n_filters % nrows != 0 else 0)
+        figsize = (ncols * 1.5, nrows * 1.5)  # Bigger squares to fit text
+
+        fig, axes = plt.subplots(nrows, ncols, figsize=figsize)
+        fig.suptitle(f"Semantic Kernels: {layer_name}", fontsize=14)
+
+        if n_filters == 1:
+            axes = [axes]
+        axes_flat = axes.flatten() if isinstance(axes, (list, np.ndarray)) else [axes]
+
+        for i in range(n_filters):
+            ax = axes_flat[i]
+
+            sim_map = max_vals[i].numpy()
+            id_map = max_ids[i].numpy()
+
+            # Plot Heatmap
+            im = ax.imshow(sim_map, cmap=COLOR, vmin=0.0, vmax=1.0)
+
+            # Overlay Text (Thanks Gemini)
+            for y in range(k_h):
+                for x in range(k_w):
+                    token_idx = id_map[y, x]
+                    # Convert index to string (safely handle if idx is out of range)
+                    if token_idx < len(self.dataset.token_to_idx):
+                        token_char = self.dataset.token_to_idx[token_idx]
+                    else:
+                        token_char = "?"
+
+                    # White text if dark background, black if light
+                    text_color = "white" if sim_map[y, x] > 0.6 else "black"
+                    ax.text(
+                        x,
+                        y,
+                        token_char,
+                        ha="center",
+                        va="center",
+                        color=text_color,
+                        fontweight="bold",
+                        fontsize=10,
+                    )
+
+            ax.set_title(f"Filter {i}", fontsize=8)
+            ax.axis("off")
+
+        # Hide unused axes
+        for j in range(i + 1, len(axes_flat)):
+            axes_flat[j].axis("off")
+
+        plt.tight_layout()
+        with PdfPages(pdf_path) as pdf:
+            pdf.savefig(fig)
+            plt.close(fig)
+
+        print(f"Saved semantic kernels to {pdf_path}")
+
+
+def main(args):
+    model_dir = Path(args.model_dir)
+    if not model_dir.exists():
+        print(f"Error: Model directory not found at {model_dir}")
+        sys.exit(1)
+
+    config_file = model_dir / ".hydra" / "config.yaml"
+    if not config_file.exists():
+        print(f"Error: Config file not found at {config_file}")
+        sys.exit(1)
+
+    cfg = OmegaConf.load(config_file)
+    cfg.resume_ckpt = model_dir / "checkpoints" / args.ckpt
+
+    print(f"Loading model from: {cfg.resume_ckpt}")
+    trainer = Trainer(cfg, model_dir)
+    trainer.model.eval()
+
+    dataset = trainer.val_dataset
+    plotter = Plotter(dataset, trainer, model_dir)
+
+    sample = trainer.fabric.to_device(dataset.get_example())
+    pretty_print_sample(dataset, sample)
+
+    # If no activation layers are provided, we pass None/Empty to InferenceTrace
+    target_layers = args.activation_layers if args.activation_layers else []
+
+    with torch.no_grad():
+        # Initialize trace with the layers we want to monitor
+        trace = InferenceTrace(trainer, sample, target_layers)
+
+    if args.plot_probabilities:
+        print("Plotting Probabilities...")
+        plotter.plot_probabilities(trace)
+
+    if args.plot_attention:
+        print("Plotting Attention...")
+        plotter.plot_attention_analysis(trace)
+
+    if args.activation_layers:
+        print(f"Plotting Activations for: {args.activation_layers}")
+        plotter.plot_layer_activations(trace)
+
+    if args.plot_conv_kernels:
+        print("Plotting Convolution Kernels...")
+        plotter.plot_conv_kernels()
+
+    if args.semantic_kernel_layer:
+        print(f"Plotting Semantic Kernels for: {args.semantic_kernel_layer}")
+        plotter.plot_semantic_kernels(args.semantic_kernel_layer, trainer.model.src_embed)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate interpretation plots for the Transformer.")
+
+    parser.add_argument(
+        "--model_dir",
+        type=str,
+        required=True,
+        help="Path to model directory (e.g., 'outputs/name/day/time')",
+    )
+    parser.add_argument(
+        "--ckpt",
+        type=str,
+        default="ckpt_0120.pth",
+        help="Checkpoint filename (default: ckpt_0120.pth)",
+    )
+
+    # Boolean Flags
+    parser.add_argument(
+        "--no-probs",
+        action="store_false",
+        dest="plot_probabilities",
+        help="Disable probability plotting",
+    )
+    parser.add_argument(
+        "--no-attn",
+        action="store_false",
+        dest="plot_attention",
+        help="Disable attention analysis plotting",
+    )
+    parser.add_argument(
+        "--no-kernels",
+        action="store_false",
+        dest="plot_conv_kernels",
+        help="Disable convolution kernel plotting",
+    )
+
+    # Set defaults to True
+    parser.set_defaults(plot_probabilities=True, plot_attention=True, plot_conv_kernels=True)
+
+    parser.add_argument(
+        "--activation_layers",
+        nargs="+",
+        default=[],
+        help="List of layer names to plot activations for (e.g. '_forward_module.lens.0' 'lens.3'). Returns empty list if not provided.",
+    )
+
+    parser.add_argument(
+        "--semantic_kernel_layer",
+        type=str,
+        default="",
+        help="Layer name for semantic kernel analysis. Leave empty to skip.",
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/plotting/traces.py
+++ b/plotting/traces.py
@@ -1,0 +1,134 @@
+from typing import List, Dict, Tuple
+from dataclasses import dataclass, field
+import torch
+from torch import Tensor
+from train import Trainer
+from utils import ActivationMonitor
+
+
+@dataclass
+class TraceHistory:
+    """Container for the history of a specific inference mode."""
+
+    steps: List[Tensor] = field(default_factory=list)  # Calculation steps
+    indices: List[Tuple[int, int]] = field(default_factory=list)  # Indices of changed elements
+    attentions: List[Tensor] = field(default_factory=list)  # Attention weights
+    y_preds: List[Tensor] = field(default_factory=list)  # Predicted distributions
+    activations: List[Dict[str, Tensor]] = field(default_factory=list)  # Recorded activations
+
+
+class InferenceTrace:
+    """Runs inference on a sample and records traces for:
+    - Single-step prediction using previous GT step
+    - Completion prediction using previous predicted step
+
+    This could be used to analyze error accumulation over steps and recovery?
+    """
+
+    def __init__(self, trainer: Trainer, sample: Tensor, layer_names: List[str] = []):
+        """Initialize inference trace on sample.
+
+        Args:
+            trainer: Trainer with model to use for inference.
+            sample: Sample calculation steps
+            layer_names: Names of layers to monitor. Defaults to [].
+        """
+
+        self.gt = TraceHistory()  # ground truth steps
+        self.single = TraceHistory()  # using previous GT step
+        self.completion = TraceHistory()  # using previous pred step
+
+        self.n_steps = sample.shape[0]
+        self.error_steps: List[int] = []
+        self.layer_names = layer_names
+
+        self._run_inference(trainer, sample)
+
+    def _run_inference(self, trainer: Trainer, sample: Tensor) -> None:
+        """Runs the inference process and records traces.
+
+        Args:
+            trainer: Trainer with model to use for inference.
+            sample: Sample calculation steps
+        """
+        # Initialize with the first step (t=0)
+        initial_step = sample[0:1]
+        self.gt.steps.append(initial_step)
+        self.single.steps.append(initial_step)
+        self.completion.steps.append(initial_step)
+
+        # Initialize the monitor for activations if needed
+        with ActivationMonitor(trainer.model, self.layer_names) as monitor:
+            for i in range(1, self.n_steps):
+                self.gt.steps.append(sample[i : i + 1])
+                self._record_diff(self.gt, i, sample[i - 1 : i])
+
+                # Single step inference using previous GT
+                self._predict_step(
+                    trainer,
+                    input_step=sample[i - 1 : i],
+                    history=self.single,
+                    monitor=monitor,
+                )
+
+                # Completion inference using previous predicted step
+                self._predict_step(
+                    trainer,
+                    input_step=self.completion.steps[-1],
+                    history=self.completion,
+                    monitor=monitor,
+                )
+
+    def _predict_step(
+        self,
+        trainer: Trainer,
+        input_step: Tensor,
+        history: TraceHistory,
+        monitor: ActivationMonitor,
+    ) -> None:
+        """Helper method to run inference on single step with monitors.
+
+        Args:
+            trainer: Trainer with model to use for inference.
+            input_step: Input step for inference.
+            history: History object to update with results.
+            monitor: Activation monitor to track layer activations.
+        """
+
+        # Clear monitor activations, as these don't get reset automatically :)
+        monitor.activations = {}
+
+        outputs = trainer.forward((input_step, None))
+
+        y_pred = outputs[2]
+        enc_attns = outputs[5]
+
+        next_step = trainer.head.step(input_step, y_pred)
+
+        # Update History
+        history.steps.append(next_step)
+        history.y_preds.append(y_pred)
+        history.attentions.append(enc_attns)
+        history.activations.append(monitor.activations.copy())
+
+        # Record diff indices
+        diff_indices = (next_step[0] != input_step[0]).nonzero(as_tuple=False)
+        history.indices.append(tuple(diff_indices.tolist()[0]))
+
+    def _record_diff(self, history: TraceHistory, current_idx: int, prev_step: Tensor) -> None:
+        """Calculates which grid cell has been updated and stores the index.
+
+        Args:
+            history: History object to update with new index.
+            current_idx: Current step index.
+            prev_step: Previous step tensor.
+        """
+        current_step = history.steps[current_idx]
+        diff = (current_step[0] != prev_step[0]).nonzero(as_tuple=False)
+        history.indices.append(tuple(diff.tolist()[0]))
+
+    def _check_errors(self) -> None:
+        """Calculates all the indices, where the full sequence inference has made errros."""
+        for i in range(self.n_steps):
+            if not torch.equal(self.completion.steps[i], self.gt.steps[i]):
+                self.error_steps.append(i)

--- a/plotting/utils.py
+++ b/plotting/utils.py
@@ -1,0 +1,98 @@
+from typing import Any, List, Callable, Self, Optional
+from torch import Tensor
+
+
+def pretty_print_sample(dataset: Any, x: Tensor, verbose: bool = True) -> str:
+    """Pretty print a data sample.
+
+    Args:
+        dataset: Dataset object to use for string conversion.
+        x: Tensor representing the sample.
+        verbose: Whether to print the output. Defaults to True.
+
+    Returns:
+        str: Formatted string representation of the sample.
+    """
+    steps = [dataset.to_string(x[i]).split("\n") for i in range(x.shape[0])]
+
+    x_str = "\n".join("   ".join(steps[i][j] for i in range(len(steps))) for j in range(len(steps[0])))
+
+    if verbose:
+        print(x_str)
+
+    return x_str
+
+
+class ActivationMonitor:
+    """Context manager to record intermediate activations from specified layers."""
+
+    def __init__(self, model, layer_names: List[str]):
+        """Initialize activation monitor. Layer names can be found via model.named_modules().
+
+        Args:
+            model: Model to monitor.
+            layer_names: Names of layers to monitor.
+        """
+        self.model = model
+        self.layer_names = layer_names
+        self.activations = {}
+        self.hooks = []  # to store pytorch hooks
+
+    def _get_hook(self, name: str) -> Callable:
+        """Get hook capture method.
+
+        Args:
+            name: Name of the layer to capture activations from.
+
+        Returns:
+            Callable: Hook function to capture activations.
+        """
+
+        def hook(model, input, output):
+            self.activations[name] = output.detach().cpu()
+
+        return hook
+
+    def __enter__(self) -> Self:
+        """Connect hooks to the model layers.
+
+        Returns:
+            ActivationMonitor: The activation monitor instance.
+        """
+        # Register hooks on layers that match the given names
+        for name, module in self.model.named_modules():
+            if name in self.layer_names:
+                self.hooks.append(module.register_forward_hook(self._get_hook(name)))
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        # Clean up hooks so they don't slow down future inference
+        for hook in self.hooks:
+            hook.remove()
+
+
+def overlay_grid_text(
+    ax,
+    data: Tensor,
+    grid_str: str,
+    vmin: float,
+    vmax: float,
+    idx: Optional[int] = None,
+) -> None:
+    """Helper to overlay character text onto heatmaps."""
+    h, w = data.shape
+    vhalf = (vmin + vmax) / 2
+    lines = grid_str.split("\n")
+
+    for y in range(h):
+        for x in range(w):
+            if x < len(lines[y]):
+                char = lines[y][x]
+
+                if idx is not None:
+                    (i, j) = idx
+                    if (y, x) == (i, j):
+                        char = "X"
+
+                color = "white" if data[y, x] < vhalf else "black"
+                ax.text(x, y, char, ha="center", va="center", color=color, fontsize=6)


### PR DESCRIPTION
Added basic plotting script to `plotting/plotter.py`.

It fetches a single sample calculation and then plots the following:
- Output probabilities for each token at each timestep
- Attention maps from each predicted token to all others (might be extended to plot from wrong predictions as well in the future)
- Convolution kernel averages for all convolutions used
- Layer activations for a given list of layers. 
- Semantic layer analysis using cosine similarity for a single layer, plotting which embedding token has highest similarity to each kernel weight.

## New Command Line Arguments

* **`--model_dir`** (Required): Path to the model directory (e.g., `outputs/name/day/time`).
* **`--ckpt`** (Default: `ckpt_0120.pth`): Filename of the checkpoint to load.
* **`--activation_layers`** (Default: `[]`): Space-separated list of layer names to record and plot activations for (e.g., `_forward_module.lens.0 lens.3`).
* **`--semantic_kernel_layer`** (Default: `""`): Name of the layer to use for semantic kernel analysis (cosine similarity with vocab). Leave empty to skip.

### Plotting Flags
* **`--no-probs`**: Disables the probability grid plot (enabled by default).
* **`--no-attn`**: Disables the attention analysis plot (enabled by default).
* **`--no-kernels`**: Disables the standard convolution kernel plot (enabled by default).