### PR TITLE
[Eval] Add evaluation script with full steps accuracy

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,177 @@
+import os
+import sys
+import argparse
+from pathlib import Path
+from typing import List, Dict, Callable
+
+import torch
+from omegaconf import OmegaConf
+from tabulate import tabulate
+import logging
+
+from train import Trainer
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+# To add a new metric, define a function here and add it to the METRIC_REGISTRY.
+# Signature: (trainer, k_idx, epoch) -> float
+def metric_step_accuracy(trainer: Trainer, k: int, epoch: int = 0) -> float:
+    """Wrapper for the existing per-step validation."""
+    _, acc = trainer.val_epoch(0)
+    return acc
+
+
+def metric_full_sample_accuracy(trainer: Trainer, k: int, epoch: int = 0) -> float:
+    """Wrapper for full step accuracy over entire sample sequence."""
+    return trainer.val_full_sample_epoch(k=k, epoch=epoch)
+
+
+METRIC_REGISTRY: Dict[str, Callable] = {
+    "step_accuracy": metric_step_accuracy,
+    "full_sample_accuracy": metric_full_sample_accuracy,
+}
+
+
+class PrintSuppressor:
+    """Context manager to suppress stdout, stderr, and logging."""
+
+    def __enter__(self):
+        self._null_file = open(os.devnull, "w")
+        self._original_stdout = sys.stdout
+        self._original_stderr = sys.stderr
+        sys.stdout = self._null_file
+        sys.stderr = self._null_file
+        self.logger = logging.getLogger()
+        self._original_log_level = self.logger.level
+        self.logger.setLevel(logging.ERROR)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.logger.setLevel(self._original_log_level)
+        sys.stdout = self._original_stdout
+        sys.stderr = self._original_stderr
+        self._null_file.close()
+
+
+def load_trainer(model_path_str: str, ckpt_name: str, n_samples: int, digits: int) -> Trainer:
+    """Load trainer instance.
+
+    Args:
+        model_path_str: Path to model output directory.
+        ckpt_name: Checkpoint filename.
+        n_samples: Number of samples for the dataset.
+        digits: Number of digits for the dataset.
+
+    Returns:
+        Trainer: Initialized trainer with loaded model.
+    """
+    model_dir = Path(model_path_str)
+
+    config_file = model_dir / ".hydra" / "config.yaml"
+    ckpt_path = model_dir / "checkpoints" / f"{ckpt_name}"
+
+    if not config_file.exists():
+        raise FileNotFoundError(f"Config not found at {config_file}")
+
+    with PrintSuppressor():
+        cfg = OmegaConf.load(config_file)
+
+    cfg.resume_ckpt = str(ckpt_path)
+    cfg.dataset.n_samples = n_samples
+    cfg.val_split = 1.0  # Use full dataset for validation (n_samples)
+
+    cfg.dataset.max_digits = digits
+    cfg.val_min_digits = digits
+    cfg.val_max_digits = digits
+
+    with PrintSuppressor():
+        trainer = Trainer(cfg, model_dir, disable_logging=True)
+    trainer.model.eval()
+
+    return trainer
+
+
+def run_evaluation(config_path: str):
+    cfg = OmegaConf.load(config_path)
+
+    digit_range = cfg.digits
+    n_samples = cfg.samples
+
+    output_buffer = []
+
+    for metric_name in cfg.metrics:
+        if metric_name not in METRIC_REGISTRY:
+            logger.warning(f"Metric '{metric_name}' not found in registry.")
+            continue
+
+        metric_fn = METRIC_REGISTRY[metric_name]
+        logger.info(f"\n{'='*10} Evaluating: {metric_name} {'='*10}")
+
+        results = {}  # {model_name: {digit: score}}
+
+        for model_entry in cfg.models:
+            # [name, path, ckpt]
+            m_name, m_path, m_ckpt = model_entry[0], model_entry[1], str(model_entry[2])
+
+            m_ckpt = f"ckpt_{m_ckpt}.pth"
+
+            results[m_name] = {}
+
+            logger.info(f"Evaluating Model: {m_name}")
+
+            for d in digit_range:
+                with PrintSuppressor():
+                    trainer = load_trainer(m_path, m_ckpt, n_samples, d)
+                    score = metric_fn(trainer, k=d, epoch=0)
+
+                results[m_name][d] = score
+                logger.info(f"  Digits {d}: {score:.2%}")
+
+                del trainer
+
+        headers = ["Model"] + [f"{d}-digits" for d in digit_range]
+        table_rows = []
+
+        for m_name in results:
+            row = [m_name]
+            for d in digit_range:
+                val = results[m_name].get(d, 0.0)
+                row.append(f"{val:.2%}")
+            table_rows.append(row)
+
+        # console table
+        console_table = tabulate(table_rows, headers=headers, tablefmt="rounded_outline")
+        print(f"\nResults for {metric_name}:")
+        print(console_table)
+
+        # latex table
+        latex_rows = []
+        for m_name in results:
+            row = [m_name]
+            for d in digit_range:
+                val = results[m_name].get(d, 0.0)
+                row.append(f"{val*100:.1f}")  # Number only for latex, usually better
+            latex_rows.append(row)
+
+        latex_headers = ["Model"] + [str(d) for d in digit_range]
+        latex_table = tabulate(latex_rows, headers=latex_headers, tablefmt="latex_booktabs")
+
+        output_buffer.append(f"%% Metric: {metric_name}")
+        output_buffer.append(latex_table)
+        output_buffer.append("\n")
+
+    # Write latex tables to output file
+    if cfg.outfile:
+        out_path = Path(cfg.outfile)
+        with open(out_path, "w") as f:
+            f.write("\n".join(output_buffer))
+        logger.info(f"\nSaved LaTeX tables to {out_path.absolute()}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Eval Models from YAML config")
+    parser.add_argument("config", type=str, help="Path to evaluation .yaml file")
+    args = parser.parse_args()
+
+    run_evaluation(args.config)

--- a/eval_config.yaml
+++ b/eval_config.yaml
@@ -1,0 +1,13 @@
+outfile: evaluation_results.txt
+min_digit: 3
+max_digit: 100
+digits: [3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100]
+samples: 1000
+metrics:
+  - step_accuracy
+  - full_sample_accuracy
+
+models:
+  # [DisplayName, PathToOutputFolder, CheckpointNumber]
+  - ["SplitHead ($\\beta=7$)", "outputs/split_head_1_7/2026-01-12/17-11-14", 200]
+  - ["SplitHead ($\\beta=4$)", "outputs/split_head_1_4/2026-01-12/06-47-42", 200]

--- a/train.py
+++ b/train.py
@@ -290,6 +290,67 @@ class Trainer:
 
         return out
 
+    def val_full_sample_epoch(self, k: int, epoch: int) -> float:
+        device = next(self.model.parameters()).device
+        self.model.eval()
+        self.head.eval()
+
+        val_dataset = self.val_datasets[k]
+        n_samples = len(val_dataset.data)
+        correct_count = 0
+
+        # unrolling steps
+        steps_to_rollout = val_dataset.seq_len - 1
+
+        pbar = tqdm(range(n_samples), desc=f"[{k}] Rollout Epoch {epoch}")
+
+        for idx in pbar:
+            sample_digits = val_dataset.data[idx]
+            a = val_dataset._digits_to_string(sample_digits[0])
+            b = val_dataset._digits_to_string(sample_digits[1])
+
+            gt_steps = val_dataset.run_algorithm(a, b)
+
+            current_grid = torch.ones(
+                (1, val_dataset.h, val_dataset.w), dtype=torch.long
+            ) * val_dataset.token_to_idx.index("\n")
+
+            # Parse the first step string
+            s = gt_steps[0]
+            for i in range(val_dataset.h):
+                for j in range(val_dataset.w - 1):  # \n already filled
+                    current_grid[0, i, j] = val_dataset.token_to_idx.index(s.split("\n")[i][j])
+
+            current_grid = current_grid.to(device)
+
+            for _ in range(steps_to_rollout):
+                with torch.no_grad():
+                    _, _, y_pred, _, _, _, _, _, _ = self.forward((current_grid, current_grid))
+
+                    if isinstance(y_pred, tuple):
+                        y_pred_mapped = tuple(y_p for y_p in y_pred)
+                        out = self.head.step(current_grid, y_pred_mapped)
+                    else:
+                        out = self.head.step(current_grid, y_pred)
+
+                    # The prediction becomes the input for the next step
+                    current_grid = out
+
+            final_pred_str = val_dataset.to_string(current_grid[0])
+            final_gt_str = gt_steps[-1]
+
+            if final_pred_str.strip() == final_gt_str.strip():
+                correct_count += 1
+
+        print(correct_count, n_samples)
+        accuracy = correct_count / n_samples
+        logger.info(f"[{k}] Rollout Accuracy: {100*accuracy:.2f}%")
+
+        if self.log_writer:
+            self.log_writer.add_scalar(f"val/{k}_rollout_accuracy", accuracy, epoch)
+
+        return accuracy
+
     def extract_gradients(self) -> list[Tensor]:
         grads = []
         params = [*self.model.parameters(), *self.head.parameters()]

--- a/train.py
+++ b/train.py
@@ -321,17 +321,13 @@ class Trainer:
                 for j in range(val_dataset.w - 1):  # \n already filled
                     current_grid[0, i, j] = val_dataset.token_to_idx.index(s.split("\n")[i][j])
 
-            current_grid = current_grid.to(device)
+            current_grid = self.fabric.to_device(current_grid)
 
             for _ in range(steps_to_rollout):
                 with torch.no_grad():
                     _, _, y_pred, _, _, _, _, _, _ = self.forward((current_grid, current_grid))
 
-                    if isinstance(y_pred, tuple):
-                        y_pred_mapped = tuple(y_p for y_p in y_pred)
-                        out = self.head.step(current_grid, y_pred_mapped)
-                    else:
-                        out = self.head.step(current_grid, y_pred)
+                    out = self.head.step(current_grid, y_pred)
 
                     # The prediction becomes the input for the next step
                     current_grid = out


### PR DESCRIPTION
Added new metric to log whether the full sequence is predicted correctly (c.f. https://arxiv.org/abs/2405.17399v1)

## Evaluation Script
New file `eval.py` which takes a config file (e.g. `eval_config.yaml`) as parameter:
```yaml
outfile: evaluation_results.txt
min_digit: 3
max_digit: 100
digits: [3, 4, 5, 6, 7, 8, 9, 10, 20, 50, 100]
samples: 1000
metrics:
  - step_accuracy
  - full_sample_accuracy

models:
  # [DisplayName, PathToOutputFolder, CheckpointNumber]
  - ["SplitHead ($\\beta=7$)", "outputs/split_head_1_7/2026-01-12/17-11-14", 200]
  - ["SplitHead ($\\beta=4$)", "outputs/split_head_1_4/2026-01-12/06-47-42", 200]
```
For each `metric` it prints a table per metric and stores all tables in latex format in `outfile`. 